### PR TITLE
Add KDE system icon support

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -364,6 +364,11 @@ int options (int argc, char *argv[]) {
 			sprintf(logo_letter, "T");
 			logo = True;
 		}
+		else OPTION("--kde", key)
+		{
+			sprintf(logo_letter, "Y");
+			logo = True;
+		}
 		else OR_OPTION_START("-h", key) OR_OPTION_END("--help", key)
 		{
 			help();


### PR DESCRIPTION
Adds support for KDE system icon using --kde as a parameter.

I noticed when working on ccgui that Gnome and XFCE were supported but there was no option for KDE.  Icon already exists in OpenLogos font so this simple edit should be sufficient.
