### PR TITLE
Fixed problem with clock vertical alignment on more than 2 cpus

### DIFF
--- a/conkycolors/scripts/conkyRing.lua
+++ b/conkycolors/scripts/conkyRing.lua
@@ -937,7 +937,7 @@ function conky_main(color, theme, n_cpu)
 
 --------------------------------------------------------------------------------
 --                                                                         clock
-	yp = yp + 64 + 7
+	yp = yp + 64 + 25
 	settings = {-- HOURS
 		value=tonumber(conky_parse("${time %H}")),
 		value_max=12             ,
@@ -995,7 +995,7 @@ function conky_main(color, theme, n_cpu)
 --------------------------------------------------------------------------------
 --                                                                continue rings
 
-	yp = yp + 64 + 44
+	yp = yp + 64 + 19
 	disks = {'/', '/home'}
 	disksLabel = {'ROOT', 'HOME'}
 	for i, partitions in ipairs(disks) do


### PR DESCRIPTION
Hi there,

i modified conkyRing.lua so that it will correctly align the clock for more than 2 cores. Also added support for up to 8 cores.

Regards
