### PR TITLE
Fix SLS when swap is disabled #22

### DIFF
--- a/conkycolors/scripts/conkySLS.lua
+++ b/conkycolors/scripts/conkySLS.lua
@@ -837,8 +837,15 @@ function conky_main(color, theme, drawbg, weather_code, battery_value)
 		};draw_gauge_bars(settings)
 		xp = xp + 5
 	end
+
+	swapperc = tonumber(conky_parse("${swapperc}"))
+	if swapperc then
+		swapperc = swapperc .. '%'		
+	else
+		swapperc = "N/A"
+	end
 	settings = {
-		txt=tonumber(conky_parse("${swapperc}")) .. '%',
+		txt=swapperc      ,
 		x=xp-45           , y=yp+15        ,
 		txt_weight=1      , txt_size=14    ,
 		txt_fg_colour=bgc , txt_fg_alpha=1 ,


### PR DESCRIPTION
Prevents display being incomplete and errors in console regarding concatenating a nil value.

When no swap is present, display reads N/A.
When swap is present, show percentage.

Fixes #22
