### PR TITLE
Replace /usr/bin/python by /usr/bin/python3 (for bullseye support)

### DIFF
--- a/conkycolors/bin/conkyBanshee
+++ b/conkycolors/bin/conkyBanshee
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkyCalendar
+++ b/conkycolors/bin/conkyCalendar
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkyClementine
+++ b/conkycolors/bin/conkyClementine
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkyClock_h
+++ b/conkycolors/bin/conkyClock_h
@@ -1,3 +1,3 @@
 #! /bin/sh
 DIR=$(conky-colors --finddir=scripts/conkyClock_h.py)
-$PYTHONPATH /usr/bin/python $DIR/scripts/conkyClock_h.py "$@"
+$PYTHONPATH /usr/bin/python3 $DIR/scripts/conkyClock_h.py "$@"

--- a/conkycolors/bin/conkyClock_m
+++ b/conkycolors/bin/conkyClock_m
@@ -1,3 +1,3 @@
 #! /bin/sh
 DIR=$(conky-colors --finddir=scripts/conkyClock_m.py)
-$PYTHONPATH /usr/bin/python $DIR/scripts/conkyClock_m.py "$@"
+$PYTHONPATH /usr/bin/python3 $DIR/scripts/conkyClock_m.py "$@"

--- a/conkycolors/bin/conkyEmail
+++ b/conkycolors/bin/conkyEmail
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkyHD1
+++ b/conkycolors/bin/conkyHD1
@@ -2,6 +2,6 @@
 DIR=$(conky-colors --finddir=scripts/conkyHD1.py)
 pythoncmd="$DIR/scripts/conkyHD1.py $@"
 
-cmd="/usr/bin/python $pythoncmd"
+cmd="/usr/bin/python3 $pythoncmd"
 
 exec $cmd

--- a/conkycolors/bin/conkyHD2
+++ b/conkycolors/bin/conkyHD2
@@ -2,6 +2,6 @@
 DIR=$(conky-colors --finddir=scripts/conkyHD2.py)
 pythoncmd="$DIR/scripts/conkyHD2.py $@"
 
-cmd="/usr/bin/python $pythoncmd"
+cmd="/usr/bin/python3 $pythoncmd"
 
 exec $cmd

--- a/conkycolors/bin/conkyHD3
+++ b/conkycolors/bin/conkyHD3
@@ -2,6 +2,6 @@
 DIR=$(conky-colors --finddir=scripts/conkyHD3.py)
 pythoncmd="$DIR/scripts/conkyHD3.py $@"
 
-cmd="/usr/bin/python $pythoncmd"
+cmd="/usr/bin/python3 $pythoncmd"
 
 exec $cmd

--- a/conkycolors/bin/conkyHD4
+++ b/conkycolors/bin/conkyHD4
@@ -2,6 +2,6 @@
 DIR=$(conky-colors --finddir=scripts/conkyHD4.py)
 pythoncmd="$DIR/scripts/conkyHD4.py $@"
 
-cmd="/usr/bin/python $pythoncmd"
+cmd="/usr/bin/python3 $pythoncmd"
 
 exec $cmd

--- a/conkycolors/bin/conkyKeyring
+++ b/conkycolors/bin/conkyKeyring
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkyRhythmbox
+++ b/conkycolors/bin/conkyRhythmbox
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkySlideshow
+++ b/conkycolors/bin/conkySlideshow
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd "$@"

--- a/conkycolors/bin/conkyZimCalendar
+++ b/conkycolors/bin/conkyZimCalendar
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd

--- a/conkycolors/bin/conkyZimEvents
+++ b/conkycolors/bin/conkyZimEvents
@@ -10,7 +10,7 @@ elif [ -f /usr/bin/python2.6 ] ; then
 	cmd="/usr/bin/python2.6 $pythoncmd"
 else
 	# here's hoping!
-	cmd="/usr/bin/python $pythoncmd"
+	cmd="/usr/bin/python3 $pythoncmd"
 fi
 
 exec $cmd


### PR DESCRIPTION
Python2 binaries are deprecated on Debian Bullseye (testing). 
These modifications fix this problem.