### PR TITLE
Change prefix on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX=/usr/local
+PREFIX=/usr
 VPATH=src/
 CFLAGS:=$(CFLAGS) -fcommon -DDESTDIR=\"$(DESTDIR)$(PREFIX)\" -Wall -std=c99
 CWD:=$(shell pwd)


### PR DESCRIPTION
My conkycolors packaging on Kaisen Linux has /usr for prefix.
Although this does not correct any problem, it helps standardize its integration into a GNU / Linux distribution. The path / usr / local being suitable for local compilation, / usr / me seems more suitable for its distribution in packages.