### PR TITLE
Fix BTRFS snapshots and Docker BTRFS mountpoint displays in Conky.

### DIFF
--- a/conkycolors/scripts/hdcommon.py
+++ b/conkycolors/scripts/hdcommon.py
@@ -5,23 +5,20 @@ from os.path import normpath, basename, ismount
 from subprocess import Popen, PIPE
 
 def get_partitions():
-    p_lsblk = Popen(['lsblk'], stdout=PIPE)
-    p_awk = Popen(['awk', '{print $7}'], stdin=p_lsblk.stdout, stdout=PIPE)
-    p_grep = Popen(['grep', '/'], stdin=p_awk.stdout, stdout=PIPE)
-    p_lsblk.stdout.close()
-    p_awk.stdout.close()
-    output = p_grep.communicate()[0]
+    p_df = Popen(['df'], stdout=PIPE)
+    p_awk = Popen(['awk', '{print $6}'], stdin=p_df.stdout, stdout=PIPE)
+    p_df.stdout.close()
+    output = p_awk.communicate()[0]
     for line in output.splitlines():
         device = line.rstrip().decode('utf-8')
         if not ismount(device):
             continue
-        if device.startswith('/snap/') or device == '/boot/efi':
+        if device.startswith(('/snap/', '/var/lib/docker/btrfs', '/boot/efi', '/dev', '/run', '/tmp/apt-btrfs-snapshot')):
             continue
         if (device == "/"):
             yield device, "Root"
         else:
             yield device, basename(normpath(device)).capitalize()
-
 
 def get_pie_chart_icon(device):
     stat = os.statvfs(device)


### PR DESCRIPTION
Bug noticed on Kaisen Linux distribution in version 1.8 and 2.0RC4.
With the lsblk command, mount points created by BTRFS snapshots (for example with Timeshift or apt-btrfs-snapshot) and the Docker daemon activated, two mount points pointing to the same path conflict with the hdcommon.py script and the / partition is not displayed anymore or displays the name of the snapshot volume.

So I modified lsblk with the df command, with an exclude of /run and /dev as well as /tmp/apt-btrfs-snapshot (the exclude didn't work with lsblk), to correct this problem and display only the partitions created manually by the user.