### PR TITLE
Add patch to no display BTRFS snapshots mountpoints and Docker BTRFS …

### DIFF
--- a/conkycolors/scripts/hdcommon.py
+++ b/conkycolors/scripts/hdcommon.py
@@ -5,23 +5,18 @@ from os.path import normpath, basename, ismount
 from subprocess import Popen, PIPE
 
 def get_partitions():
-    p_lsblk = Popen(['lsblk'], stdout=PIPE)
-    p_awk = Popen(['awk', '{print $7}'], stdin=p_lsblk.stdout, stdout=PIPE)
-    p_grep = Popen(['grep', '/'], stdin=p_awk.stdout, stdout=PIPE)
-    p_lsblk.stdout.close()
-    p_awk.stdout.close()
-    output = p_grep.communicate()[0]
+    p_lsblk = Popen(['lsblk', '-o', 'MOUNTPOINTS'], stdout=PIPE)
+    output = p_lsblk.communicate()[0]
     for line in output.splitlines():
         device = line.rstrip().decode('utf-8')
         if not ismount(device):
             continue
-        if device.startswith('/snap/') or device == '/boot/efi':
+        if device.startswith(('/snap/', '/var/lib/docker/btrfs', '/boot/efi', '/run/timeshift', '/tmp/apt-btrfs-snapshot', '/usr/lib/live/mount')):
             continue
         if (device == "/"):
             yield device, "Root"
         else:
             yield device, basename(normpath(device)).capitalize()
-
 
 def get_pie_chart_icon(device):
     stat = os.statvfs(device)


### PR DESCRIPTION
With the original code, all BTRFS mountpoints and Docker mountpoint are display or not display by Conky.

AWK and grep don't include all mountpoints for a partition. For example, with BTRFS, when timeshift is used to take a snapshot of the / partition, a mountpoint is created, in this example, only mountpoint created by Timeshift was displayed in Conky but not the real mountpoint for the / partition.

The command lsblk -o MOUNTPOINTS and the exclude mountpoints created by Timeshift or apt-btrfs-snapshot fix this problem.

What's more, the mounting points with spaces are also displayed by Conky now.